### PR TITLE
fix download_dir variable name

### DIFF
--- a/bootstrap/integrate.sh.template
+++ b/bootstrap/integrate.sh.template
@@ -19,7 +19,7 @@ download() {
 
 if ! command -v 0install > /dev/null 2> /dev/null; then
   download
-  $DOWNLOAD_DIR/install.sh home
+  $download_dir/install.sh home
 fi
 
 if [ -d "$CONTENT_DIR" ]; then

--- a/bootstrap/run.sh.template
+++ b/bootstrap/run.sh.template
@@ -20,7 +20,7 @@ if command -v 0install > /dev/null 2> /dev/null; then
     ZEROINSTALL=0install
 else
     download
-    ZEROINSTALL=$DOWNLOAD_DIR/files/0install
+    ZEROINSTALL=$download_dir/files/0install
 fi
 
 if [ -d "$CONTENT_DIR" ]; then


### PR DESCRIPTION
Variable name needs to be lower case.

Without this change the run/integrate script fails because `$DOWNLOAD_DIR/files/0install` expands to `/files/0install`

Issue introduced in `2110b542c4a296bae58970f8055b907b8f5e446e`